### PR TITLE
Add PBS API MCP Server

### DIFF
--- a/data/servers/list.json
+++ b/data/servers/list.json
@@ -231,6 +231,13 @@
       "repo_url": "https://github.com/varunneal/spotify-mcp",
       "tags": ["integration", "monitor", "analysis"],
       "language": "python"
+    },
+    {
+      "name": "PBS API",
+      "description": "A standalone Model Context Protocol (MCP) server that allows AI models to access the Australian Pharmaceutical Benefits Scheme (PBS) API, which contains information about medicines, pricing, and availability in Australia.",
+      "repo_url": "https://github.com/matthewdcage/pbs-mcp-server",
+      "tags": ["storage", "integration"],
+      "language": "typescript"
     }
   ]
 }


### PR DESCRIPTION
Adding the Australian Pharmaceutical Benefits Scheme (PBS) API MCP Server to the server list.

This server provides:
- Access to Australian PBS pharmaceutical data through natural language queries
- Support for both stdio and HTTP/SSE transport layers
- Comprehensive error handling for API rate limits
- Natural language processing of medication-related queries

Repository: https://github.com/matthewdcage/pbs-mcp-server