### PR TITLE
Add Roundtable MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 ### ai
 
 - [Knowledge Graph Memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) - <img src="./images/languages/typescript.svg" > A basic implementation of persistent memory using a local knowledge graph. This lets LLM remember information about the user across chats.
+- [Roundtable](https://github.com/deadpixel/roundtable-dashboard) - <img src="./images/languages/typescript.svg" > Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss, then synthesize insight. Tools: consult, review_code, debug, architect, plan_implementation, assess_tradeoffs.
 - [Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking) - <img src="./images/languages/typescript.svg" > An MCP server implementation that provides a tool for dynamic and reflective problem-solving through a structured thinking process.
 
 ### analysis

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ### ai
 
 - [Knowledge Graph Memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) - <img src="./images/languages/typescript.svg" > A basic implementation of persistent memory using a local knowledge graph. This lets LLM remember information about the user across chats.
-- [Roundtable](https://github.com/deadpixel/roundtable-dashboard) - <img src="./images/languages/typescript.svg" > Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss, then synthesize insight. Tools: consult, review_code, debug, architect, plan_implementation, assess_tradeoffs.
+- [Roundtable](https://github.com/deadpixel/roundtable-dashboard) - <img src="./images/languages/typescript.svg" > Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss, then synthesize insight. Tools: consult_council, review_code, debug_issue, design_architecture, plan_implementation, assess_tradeoffs.
 - [Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking) - <img src="./images/languages/typescript.svg" > An MCP server implementation that provides a tool for dynamic and reflective problem-solving through a structured thinking process.
 
 ### analysis


### PR DESCRIPTION
## Add Roundtable MCP Server

**Roundtable** is a multi-model AI debate platform where GPT-4o, Claude, Gemini & 200+ models discuss your question collaboratively, then a moderator synthesizes all perspectives into actionable insight.

- **Repository**: https://github.com/deadpixel/roundtable-dashboard
- **Website**: https://roundtable.now
- **MCP Endpoint**: `https://mcp.roundtable.now/mcp` (Streamable HTTP)
- **Auth**: API Key (`rpnd_` prefix)

### MCP Tools (13 total)

| Tool | Description |
|------|-------------|
| `consult_council` | Multi-model roundtable discussion on any question |
| `review_code` | Multi-perspective code review |
| `debug_issue` | Multi-angle bug diagnosis |
| `design_architecture` | Architecture design council |
| `plan_implementation` | Implementation planning with consensus |
| `assess_tradeoffs` | Evaluate technical tradeoffs |
| `check_usage` | Check credits and rate limits |
| `list_models` | List available AI models |
| `list_sessions` | List past debate sessions |
| `get_session` | Retrieve session results |
| `get_thread_link` | Get shareable thread link |
| `set_thread_visibility` | Toggle thread visibility |
| `get_logs` | View invocation logs |

### Key Features
- Auto-mode: AI picks optimal models, roles, and conversation mode
- Configurable thinking levels (low/medium/high)
- Session persistence and thread sharing
- 3 built-in prompts, 3 resources